### PR TITLE
Added output file name option

### DIFF
--- a/bin/convert_font
+++ b/bin/convert_font
@@ -30,6 +30,10 @@ opt_parser = OptionParser.new do |opt|
   opt.on("-c", "--cleanup CLEANUP", "If you DON'T want the downloaded .tar.gz files to be cleaned up, ex. -c false") do |cleanup|
     options[:cleanup] = cleanup
   end
+
+  opt.on("-o", "--output_file FILE", "Output file name. If ommitted the fontfaimly will be used as file name") do |output_file|
+    options[:output_file] = output_file
+  end
 end
 
 opt_parser.parse!
@@ -48,7 +52,7 @@ if ARGV[0]
   elsif options[:formats].nil? || options[:formats].count <= 0
     puts "Please provide at least one format to convert to. 'convert_font --help'"
   else
-    converter.convert(options[:font_file], options[:formats], destination)
+    converter.convert(options[:font_file], options[:formats], destination, options[:output_file])
   end
 else
   puts opt_parser

--- a/lib/convert_font/converter.rb
+++ b/lib/convert_font/converter.rb
@@ -19,7 +19,7 @@ module ConvertFont
       Unirest.default_header('X-Mashape-Authorization', @api_key)
     end
 
-    def convert file, types, destination
+    def convert file, types, destination, output_file_name=nil
       destination << "/" if destination[-1] != "/"
       types.to_enum.with_index(0).each do |type, i|
         puts "Now converting: #{type}"
@@ -27,20 +27,22 @@ module ConvertFont
         open("#{destination}temp_font_#{type.to_s}.tar.gz", "w") do |temp_file|
           temp_file.write(response.body)
         end
-        extract("#{destination}temp_font_#{type.to_s}.tar.gz", destination);
+        extract("#{destination}temp_font_#{type.to_s}.tar.gz", destination, output_file_name);
         puts "#{type} converted."
       end
     end
 
-    def extract file, destination
+    def extract file, destination, output_file_name=nil
       destination << "/" if destination[-1] != "/"
       tar = Gem::Package::TarReader.new(Zlib::GzipReader.open(file))
       tar.rewind
       tar.each do |entry|
         if entry.file?
-          names = entry.full_name.split("/")
-          unless names.last.include? ".txt"
-            open(destination + names.last, "wb") do |new_file|
+          name = entry.full_name.split("/").last
+          ext = name.to_s.split('.').last
+
+          unless ext == "txt"
+            open(destination + "#{output_file_name || name}.#{ext}", "wb") do |new_file|
               new_file.write(entry.read)
             end 
           end

--- a/spec/convert_font_spec.rb
+++ b/spec/convert_font_spec.rb
@@ -47,4 +47,13 @@ describe ConvertFont::Converter do
     converter.convert(File.dirname(__FILE__) + "/convert_font/SourceSansPro-Regular.otf", [:woff], File.dirname(__FILE__) + "/convert_font/")
     expect(File.file?(font_file)).to be true
   end
+
+  it "should set output filename" do
+    font_file = File.dirname(__FILE__) + "/convert_font/SourceSansPro-Regular.woff"
+    FileUtils.rm_rf font_file if File.file?(font_file)
+    converter.convert(File.dirname(__FILE__) + "/convert_font/SourceSansPro-Regular.otf", [:woff], File.dirname(__FILE__) + "/convert_font/", "newName")
+
+    new_font_file = File.dirname(__FILE__) + "/convert_font/newName.woff"
+    expect(File.file?(new_font_file)).to be true
+  end
 end


### PR DESCRIPTION
Recently converted few font files to svg, after few optimization converted svg back to fonts using another tool. Tried converting those ttf fonts again to svg and gem was rewriting fonts with same filename. Quickly added option to pass output file name.

`convert_font convert -i path/to/ttf_font.ttf -f svg -d path/to/destination -o new_font_name`  